### PR TITLE
NOJIRA: Fix CheckboxInput component page jump behavior.

### DIFF
--- a/styles/cspace-input/CheckboxInput.css
+++ b/styles/cspace-input/CheckboxInput.css
@@ -3,6 +3,7 @@
 
 .common > input {
   position: absolute;
+  display: none;
   left: -20px;
   top: -20px;
 }


### PR DESCRIPTION
Simply added CSS property 'display: none' to input.