### PR TITLE
DRYD-1305: Add tooltip prop for DateInput

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -25,12 +25,14 @@ const propTypes = {
   // eslint-disable-next-line react/forbid-foreign-prop-types
   ...BaseDropdownInput.propTypes,
   locale: PropTypes.string,
+  tooltip: PropTypes.string,
   onCommit: PropTypes.func,
   readOnly: PropTypes.bool,
 };
 
 const defaultProps = {
   locale: 'en-US',
+  tooltip: '',
   onCommit: undefined,
   readOnly: undefined,
 };

--- a/src/components/LineInput.jsx
+++ b/src/components/LineInput.jsx
@@ -124,6 +124,7 @@ export default class LineInput extends Component {
         ref={this.handleRef}
         type="text"
         value={normalizedValue}
+        title={remainingProps.tooltip}
       />
     );
 

--- a/test/specs/components/DateInput.spec.jsx
+++ b/test/specs/components/DateInput.spec.jsx
@@ -31,6 +31,14 @@ describe('DateInput', function suite() {
     expect(this.container.querySelector('.react-calendar')).to.equal(null);
   });
 
+  it('should render with a tooltip when provided', function test() {
+    const tooltip = 'test';
+    render(<DateInput tooltip={tooltip} />, this.container);
+
+    const input = this.container.querySelector('input');
+    expect(input.title).to.equal(tooltip);
+  });
+
   it('should not open on focus', function test() {
     render(<DateInput />, this.container);
 

--- a/test/specs/components/LineInput.spec.jsx
+++ b/test/specs/components/LineInput.spec.jsx
@@ -149,4 +149,12 @@ describe('LineInput', () => {
 
     document.activeElement.should.equal(input);
   });
+
+  it('should render with a tooltip when provided', function test() {
+    const tooltip = 'test';
+    render(<LineInput tooltip={tooltip} />, this.container);
+
+    const input = this.container.querySelector('input');
+    expect(input.title).to.equal(tooltip);
+  });
 });


### PR DESCRIPTION
**What does this do?**
* Adds a tooltip prop to DateInput
* Add title to LineInput to display provided tooltips

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1305

This is the first PR for adding instructions for non-standard interactions. It allows a tooltip to be passed in as a prop so that it can provide instructions for use of the input container. 

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` to ensure nothing broke
* Rebuild and deploy alongside the cspace-ui PR
* Mouseover a DateInput and see that a message is provided with instructions about usage

**Dependencies for merging? Releasing to production?**
Requires cspace-ui PR in order to provide any functionality so that internationalization can be performed on the message if desired. I was considering adding a non-internationalized version of the tooltip here as well, which would be easy to do.

I believe we need to add something similar to the other dropdown inputs, but I need to check the audit document first to be sure.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally