### PR TITLE
DRYD-1978: Increase contrast for disabled mini buttons

### DIFF
--- a/styles/cspace-input/MiniButton.css
+++ b/styles/cspace-input/MiniButton.css
@@ -22,7 +22,7 @@ div.common {
 }
 
 .common:disabled {
-  color: textMedium;
+  color: textDark;
   background-color: miniButtonBgDisabled;
 }
 


### PR DESCRIPTION
**What does this do?**
Changes the contrast for disabled MiniButton elements

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1978

This fixes an accessibility violation in the pager and other components of cspace-ui. By using the existing `textDark`, we should see a contrast ratio of ~7.

**How should this be tested? Do these changes have associated tests?**
* Rebuild cspace-input
* Deploy the updated cspace-input in your cspace-ui (npm link worked for me; I've had trouble with hooks breaking before though).
* Using the advanced search, search on any record type
* See that the pager component should have the proper contrast ratio 

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local CollectionSpace