### PR TITLE
Release 2.1.1

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -2,9 +2,9 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 2.1.1
+
+* Increase contrast in disabled mini button text
+
+## 2.1.0
+
+* Add tooltip to DateInput component
+
 ## 2.0.0
 
 Version 2.0.0 requires React 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-input",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-input",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-input",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CollectionSpace input components",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
**What does this do?**
Update the package version to 2.1.1

**Why are we doing this? (with JIRA link)**
No Jira

This is to allow us to publish a new patch version of cspace-input which can be included in the upcoming cspace-ui release.

**How should this be tested? Do these changes have associated tests?**
* Ensure that `npm run lint`, `npm run test`, and `npm run build` all execute

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally