### PR TITLE
DRYD-1925 Accessibility > Contrast/Design of Buttons (Criteria 1.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.1.2
+* Changed button color palette
+
 ## 2.1.1
 
 * Increase contrast in disabled mini button text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-input",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-input",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-input",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CollectionSpace input components",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -7,6 +7,8 @@
 @value buttonBg: #003366;
 @value buttonBgActive: #336699;
 @value buttonBgDisabled: #333333;
+@value deleteButtonBg: #660000;
+@value deleteButtonBgActive: #990000;
 @value miniButtonBgDisabled: rgba(230, 230, 230, .4);
 
 @value inputBg: rgb(255, 255, 255);

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -5,8 +5,8 @@
 
 @value buttonText: rgb(255, 255, 255);
 @value buttonBg: #003366;
-@value buttonBgActive: #336699;
-@value buttonBgDisabled: #333333;
+@value buttonBgActive: #305A8D;
+@value buttonBgDisabled: #4d4d4d;
 @value deleteButtonBg: #660000;
 @value deleteButtonBgActive: #990000;
 @value miniButtonBgDisabled: rgba(230, 230, 230, .4);

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -4,9 +4,9 @@
 @value textLabel: rgb(80, 80, 80);
 
 @value buttonText: rgb(255, 255, 255);
-@value buttonBg: #73AA4F;
-@value buttonBgActive: #4A7F28;
-@value buttonBgDisabled: rgb(220, 220, 220);
+@value buttonBg: #003366;
+@value buttonBgActive: #336699;
+@value buttonBgDisabled: #333333;
 @value miniButtonBgDisabled: rgba(230, 230, 230, .4);
 
 @value inputBg: rgb(255, 255, 255);


### PR DESCRIPTION
**What does this do?**
It resolves the very low contrast issue of buttons. It also changes the bg color of the delete button. The updates include:
* changing `buttonBg, buttonBgActive, buttonBgDisabled, deleteButtonBg, deleteButtonBgActive` colors.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1925

**How should this be tested? Do these changes have associated tests?**
Please check the instructions in https://github.com/collectionspace/cspace-ui.js/pull/352

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally